### PR TITLE
BI-586: Quote invalid key in strict mode error

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -582,7 +582,7 @@ done:
 				subv = subv.Field(i)
 			}
 		} else if d.strictMode {
-			d.error(fmt.Errorf("unable to map key %v to a struct field at %v", key, d.event.start_mark))
+			d.error(fmt.Errorf("unable to map key %q to a struct field at %v", key, d.event.start_mark))
 		}
 		d.parse(subv)
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -183,7 +183,7 @@ default:
 
 					err := d.Decode(&v)
 					Expect(err).To(HaveOccurred())
-					expectedErrorString := fmt.Errorf("unable to map key avg to a struct field at line 3, column 8")
+					expectedErrorString := fmt.Errorf("unable to map key \"avg\" to a struct field at line 3, column 8")
 					Expect(err).To(Equal(expectedErrorString))
 				})
 			})


### PR DESCRIPTION
This PR just tweaks https://github.com/10gen/candiedyaml/commit/cae3b8f3b45c6094af0d493533b55516956165a1 to quote the invalid key in the strict mode error.