### PR TITLE
BI-2216: Update expected bson.D field name

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -478,7 +478,7 @@ func (d *Decoder) mappingSlice(v reflect.Value) {
 	var valueField *field
 	for _, f := range fields {
 		switch f.name {
-		case "Name":
+		case "Key":
 			tempf := f
 			nameField = &tempf
 		case "Value":
@@ -490,7 +490,7 @@ func (d *Decoder) mappingSlice(v reflect.Value) {
 	// in this instance, we require that a struct
 	// with names Key and Value
 	if nameField == nil || valueField == nil {
-		d.error(fmt.Errorf("Expected a slice of a struct with fields called 'Name' and 'Value' ", v, d.event.start_mark))
+		d.error(fmt.Errorf("Expected a slice of a struct with fields called 'Key' and 'Value' ", v, d.event.start_mark))
 	}
 
 	d.nextEvent()


### PR DESCRIPTION
This PR updates the decoder to expect the new Go driver's bson.D field names. The new Go driver's `bson.D` is:
```
type D struct {
  Key string
  Value interface{}
}
```
Previously, it was "Name" instead of "Key".